### PR TITLE
(feat): added bandwidth limiter

### DIFF
--- a/lib/src/mellowtel.dart
+++ b/lib/src/mellowtel.dart
@@ -11,6 +11,7 @@ import 'package:mellowtel/src/services/s3_service.dart';
 import 'package:mellowtel/src/ui/consent_dialog.dart';
 import 'package:mellowtel/src/ui/consent_settings_dailog.dart';
 import 'package:mellowtel/src/utils/rate_limiter.dart';
+import 'package:mellowtel/src/utils/bandwidth_limiter.dart';
 import 'package:mellowtel/src/webview/macos_webview_manager.dart';
 import 'package:mellowtel/src/webview/webview_manager.dart';
 import 'package:mellowtel/src/webview/windows_webview_manager.dart';
@@ -129,6 +130,7 @@ class Mellowtel {
       }
 
       if (consent) {
+        await BandwidthLimiter(await SharedPreferences.getInstance()).resetScrapeTimes();
         await _startScraping();
       }
     } catch (e) {
@@ -223,7 +225,7 @@ class Mellowtel {
 
   void _connectWebSocket(String url, {bool test = false}) {
     if (test) {
-      _fakeSocket = Timer.periodic(const Duration(seconds: 4), (_) {
+      _fakeSocket = Timer.periodic(const Duration(seconds: 10), (_) {
         _onMessage(jsonEncode(ScrapeRequest(
                 recordID: '005ie7h3w5',
                 url: 'https://www.mellowtel.dev/',
@@ -339,6 +341,14 @@ class Mellowtel {
   Future<void> _onMessage(dynamic message) async {
     final prefs = await SharedPreferences.getInstance();
     final rateLimiter = RateLimiter(prefs);
+    final bandwidthLimiter = BandwidthLimiter(prefs);
+
+    if (await bandwidthLimiter.shouldDisconnect()) {
+      developer.log(
+          'Mellowtel: Average scrape time exceeded limit. Closing WebSocket connection.');
+      await stop();
+      return;
+    }
 
     if (await rateLimiter.getIfDailyRateLimitReached()) {
       developer.log(
@@ -361,7 +371,11 @@ class Mellowtel {
         await rateLimiter.increment();
 
         ScrapeRequest scrapeRequest = ScrapeRequest.fromJson(data);
+
+        final stopwatch = Stopwatch()..start();
         ScrapeResult scrapeResult = await _runScrapeRequest(scrapeRequest);
+        await bandwidthLimiter.addScrapeTime(stopwatch);
+
         final UploadResult uploadResult = await _postScrapeRequest(scrapeResult,
             url: scrapeRequest.url,
             htmlTransformer: scrapeRequest.htmlTransformer);

--- a/lib/src/utils/bandwidth_limiter.dart
+++ b/lib/src/utils/bandwidth_limiter.dart
@@ -1,0 +1,37 @@
+import 'dart:math';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+class BandwidthLimiter {
+  static const String _scrapeTimesKey = 'mellowtel_scrape_times';
+  static const int maxScrapeTimes = 3;
+  static const int maxAllowedTime = 10000;
+
+  final SharedPreferences _prefs;
+
+  BandwidthLimiter(this._prefs);
+
+  Future<void> addScrapeTime(Stopwatch stopwatch) async {
+    final time = stopwatch.elapsedMilliseconds;
+    stopwatch.stop();
+    List<int> scrapeTimes = _prefs.getStringList(_scrapeTimesKey)?.map((e) => int.parse(e)).toList() ?? [];
+    if (scrapeTimes.length >= maxScrapeTimes) {
+      scrapeTimes.removeAt(0);
+    }
+    scrapeTimes.add(time);
+    await _prefs.setStringList(_scrapeTimesKey, scrapeTimes.map((e) => e.toString()).toList());
+  }
+
+  Future<bool> shouldDisconnect() async {
+    List<int> scrapeTimes = _prefs.getStringList(_scrapeTimesKey)?.map((e) => int.parse(e)).toList() ?? [];
+    if (scrapeTimes.length < maxScrapeTimes) {
+      return false;
+    }
+    int minimumScrapeTime = scrapeTimes.reduce((a, b) => min(a, b));
+    return minimumScrapeTime > maxAllowedTime;
+  }
+
+  Future<void> resetScrapeTimes() async {
+    await _prefs.remove(_scrapeTimesKey);
+  }
+}


### PR DESCRIPTION
I couldn't find a good bandwidth measurement package for Flutter. Cloudflare one used in JS is not available.

So used a slightly different logic:

We check the last 3 web scraping times. If all of them are greater than the maximum limit i.e. 10 seconds, we disconnect the web socket. It resets on the next app start.